### PR TITLE
Make login welcome message translatable

### DIFF
--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -1,6 +1,18 @@
 import { useEffect, useState } from 'react';
 import {
-  useMediaQuery, Select, MenuItem, FormControl, Button, TextField, Link, Snackbar, IconButton, Tooltip, Box, InputAdornment,
+  useMediaQuery,
+  Select,
+  MenuItem,
+  FormControl,
+  Button,
+  TextField,
+  Link,
+  Snackbar,
+  IconButton,
+  Tooltip,
+  Box,
+  InputAdornment,
+  Typography,
 } from '@mui/material';
 import ReactCountryFlag from 'react-country-flag';
 import { makeStyles } from 'tss-react/mui';
@@ -174,6 +186,9 @@ const LoginPage = () => {
         )}
       </div>
       <div className={classes.container}>
+        <Typography variant="h5" component="h1" textAlign="center">
+          {t('loginWelcomeMessage')}
+        </Typography>
         {useMediaQuery(theme.breakpoints.down('lg')) && <LogoImage color={theme.palette.primary.main} />}
         {!openIdForced && (
           <>

--- a/src/resources/l10n/af.json
+++ b/src/resources/l10n/af.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nuwe gebruiker is geregistreer",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "Nuwe wagwoord is ingestel",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Teken uit",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ar.json
+++ b/src/resources/l10n/ar.json
@@ -205,6 +205,7 @@
     "loginCreated": "تم تسجيل مستخدم جديد",
     "loginResetSuccess": "تحقق من بريدك الإلكتروني",
     "loginUpdateSuccess": "تم تعيين كلمة المرور الجديدة",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "تسجيل الخروج",
     "loginLogo": "الشعار",
     "loginTotpCode": "رمز كلمة المرور لمرة واحدة",

--- a/src/resources/l10n/az.json
+++ b/src/resources/l10n/az.json
@@ -205,6 +205,7 @@
     "loginCreated": "Yeni istifadəçi qeydiyyatdan keçmişdir",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Çıxış",
     "loginLogo": "Giriş",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/bg.json
+++ b/src/resources/l10n/bg.json
@@ -205,6 +205,7 @@
     "loginCreated": "Регистриран нов потребител",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Изход",
     "loginLogo": "Лого",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/bn.json
+++ b/src/resources/l10n/bn.json
@@ -205,6 +205,7 @@
     "loginCreated": "নতুন ব্যবহারকারী নিবন্ধিত হয়েছে",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "লগ আউট",
     "loginLogo": "লোগো",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ca.json
+++ b/src/resources/l10n/ca.json
@@ -205,6 +205,7 @@
     "loginCreated": "S'ha registrat un usuari nou",
     "loginResetSuccess": "Comprova el teu email",
     "loginUpdateSuccess": "S'ha creat la nova contrasenya",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Tancar Sessió",
     "loginLogo": "Logotipus",
     "loginTotpCode": "Codi de contrasenya d'un sol ús",

--- a/src/resources/l10n/cs.json
+++ b/src/resources/l10n/cs.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nový uživatel byl zaregistrován",
     "loginResetSuccess": "Zkontroluj si email ",
     "loginUpdateSuccess": "Nové heslo je nastaveno",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Odhlášení",
     "loginLogo": "Logo",
     "loginTotpCode": "Dvoufaktorová autentifikace kód",

--- a/src/resources/l10n/da.json
+++ b/src/resources/l10n/da.json
@@ -205,6 +205,7 @@
     "loginCreated": "Ny bruger er registreret",
     "loginResetSuccess": "Tjek din e-mail",
     "loginUpdateSuccess": "Ny adgangskode er indstillet",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Log af",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/de.json
+++ b/src/resources/l10n/de.json
@@ -205,6 +205,7 @@
     "loginCreated": "Neuer Benutzer wurde registriert",
     "loginResetSuccess": "Prüfen Sie Ihre E-Mails",
     "loginUpdateSuccess": "Neues Passwort gespeichert",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Abmelden",
     "loginLogo": "Logo",
     "loginTotpCode": "OTP-Code",

--- a/src/resources/l10n/el.json
+++ b/src/resources/l10n/el.json
@@ -205,6 +205,7 @@
     "loginCreated": "Ο νέος χρήστης καταχωρήθηκε.",
     "loginResetSuccess": "Ελέγξτε τα email σας",
     "loginUpdateSuccess": "Το νέο συνθηματικό αποθηκεύθηκε",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Αποσύνδεση",
     "loginLogo": "Λογότυπο",
     "loginTotpCode": "Κωδικός One-time Password",

--- a/src/resources/l10n/en.json
+++ b/src/resources/l10n/en.json
@@ -205,6 +205,7 @@
     "loginCreated": "New user has been registered",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logout",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/es.json
+++ b/src/resources/l10n/es.json
@@ -205,6 +205,7 @@
     "loginCreated": "Se ha registrado un nuevo usuario",
     "loginResetSuccess": "Comprueba tu email",
     "loginUpdateSuccess": "Se ha creado la nueva contraseña",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Cerrar Sesión",
     "loginLogo": "Logotipo",
     "loginTotpCode": "Código de un solo uso",

--- a/src/resources/l10n/et.json
+++ b/src/resources/l10n/et.json
@@ -205,6 +205,7 @@
     "loginCreated": "New user has been registered",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logout",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/fa.json
+++ b/src/resources/l10n/fa.json
@@ -205,6 +205,7 @@
     "loginCreated": "ثبت نام با موفقيت انجام شد",
     "loginResetSuccess": "ایمیلتان را چک کنید",
     "loginUpdateSuccess": "رمز جدید اعمال شد",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "خروج",
     "loginLogo": "لوگو",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/fi.json
+++ b/src/resources/l10n/fi.json
@@ -205,6 +205,7 @@
     "loginCreated": "Uusi käyttäjä on rekisteröity",
     "loginResetSuccess": "Tarkista sähköpostisi",
     "loginUpdateSuccess": "Uusi salasana asetettu",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Kirjaudu ulos",
     "loginLogo": "Logo",
     "loginTotpCode": "Kertakäyttö salasana koodi",

--- a/src/resources/l10n/fr.json
+++ b/src/resources/l10n/fr.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nouvel utilisateur enregistré",
     "loginResetSuccess": "Vérifiez vos emails",
     "loginUpdateSuccess": "Le nouveau mot de passe est défini",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Déconnexion",
     "loginLogo": "Logo",
     "loginTotpCode": "Code OTP",

--- a/src/resources/l10n/gl.json
+++ b/src/resources/l10n/gl.json
@@ -205,6 +205,7 @@
     "loginCreated": "Rexistrouse un novo usuario",
     "loginResetSuccess": "Comprobe o seu correo electrónico",
     "loginUpdateSuccess": "Establécese un novo contrasinal",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Pechar sesión",
     "loginLogo": "Logotipo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/he.json
+++ b/src/resources/l10n/he.json
@@ -205,6 +205,7 @@
     "loginCreated": "משתמש חדש נרשם",
     "loginResetSuccess": "בדוק את האימייל שלך",
     "loginUpdateSuccess": "הסיסמה החדשה הוגדרה",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "יציאה",
     "loginLogo": "לוגו",
     "loginTotpCode": "קוד סיסמה חד פעמי",

--- a/src/resources/l10n/hi.json
+++ b/src/resources/l10n/hi.json
@@ -205,6 +205,7 @@
     "loginCreated": "नया उपयोगकर्ता पंजीकृत हो गया है",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "लॉगआउट /  निष्कासन करें",
     "loginLogo": "लोगो",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/hr.json
+++ b/src/resources/l10n/hr.json
@@ -205,6 +205,7 @@
     "loginCreated": "Registiran je novi korisnik",
     "loginResetSuccess": "Provjeri e-poštu",
     "loginUpdateSuccess": "Postavljena je nova lozinka",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Odjava",
     "loginLogo": "Logo",
     "loginTotpCode": "Jednokratna lozinka",

--- a/src/resources/l10n/hu.json
+++ b/src/resources/l10n/hu.json
@@ -205,6 +205,7 @@
     "loginCreated": "Az új felhasználó sikeresen létrehozva",
     "loginResetSuccess": "Ellenőrizd az emailedet",
     "loginUpdateSuccess": "Új jelszó beállítva",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Kilépés",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/hy.json
+++ b/src/resources/l10n/hy.json
@@ -205,6 +205,7 @@
     "loginCreated": "New user has been registered",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logout",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/id.json
+++ b/src/resources/l10n/id.json
@@ -205,6 +205,7 @@
     "loginCreated": "Pengguna Baru Telah Terdaftar",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Keluar",
     "loginLogo": "Lambang",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/it.json
+++ b/src/resources/l10n/it.json
@@ -205,6 +205,7 @@
     "loginCreated": "Un nuovo utente si è registrato",
     "loginResetSuccess": "Controlla la tua email",
     "loginUpdateSuccess": "Nuova password impostata",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Esci",
     "loginLogo": "Logo",
     "loginTotpCode": "Codice Password Monouso",

--- a/src/resources/l10n/ja.json
+++ b/src/resources/l10n/ja.json
@@ -205,6 +205,7 @@
     "loginCreated": "新しいユーザーが登録されました",
     "loginResetSuccess": "メールを確認してください",
     "loginUpdateSuccess": "新しいパスワードが設定されました",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "ログアウト",
     "loginLogo": "ロゴ",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ka.json
+++ b/src/resources/l10n/ka.json
@@ -205,6 +205,7 @@
     "loginCreated": "ახალი მომხარებელი დარეგისტრირდა",
     "loginResetSuccess": "შეამოწმეთ თქვენი ელექტორნული ფოსტა",
     "loginUpdateSuccess": "ახალი პაროლი დაყენებულია",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "გამოსვლა",
     "loginLogo": "ლოგო",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/kk.json
+++ b/src/resources/l10n/kk.json
@@ -205,6 +205,7 @@
     "loginCreated": "Жаңа қолданушы тіркелді",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Шығу",
     "loginLogo": "Логотип",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/km.json
+++ b/src/resources/l10n/km.json
@@ -205,6 +205,7 @@
     "loginCreated": "អ្នកប្រើថ្មីត្រូវបានចុះបញ្ជី",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "ចាកចេញ",
     "loginLogo": "រូបសញ្ញា",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ko.json
+++ b/src/resources/l10n/ko.json
@@ -205,6 +205,7 @@
     "loginCreated": "회원가입 되었습니다.",
     "loginResetSuccess": "이메일을 확인해주세요",
     "loginUpdateSuccess": "비밀번호가 변경되었습니다",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "로그아웃",
     "loginLogo": "로고",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/lo.json
+++ b/src/resources/l10n/lo.json
@@ -205,6 +205,7 @@
     "loginCreated": "ຜູ້ໃຊ້ໃຫມ່ ໄດ້ຮັບການລົງທະບຽນ",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "ອອກຈາກລະບົບ",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/lt.json
+++ b/src/resources/l10n/lt.json
@@ -205,6 +205,7 @@
     "loginCreated": "Registracija sėkminga",
     "loginResetSuccess": "Patikrinkite savo el. paštą",
     "loginUpdateSuccess": "Naujas slaptažodis sukurtas",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Atsijungti",
     "loginLogo": "Logotipas",
     "loginTotpCode": "Vienkartinio slaptažodžio kodas",

--- a/src/resources/l10n/lv.json
+++ b/src/resources/l10n/lv.json
@@ -205,6 +205,7 @@
     "loginCreated": "Jauns lietotājs tika veiksmīgi reģistrēts ",
     "loginResetSuccess": "Pārbaudiet savu e-pastu",
     "loginUpdateSuccess": "Jaunā parole saglabāta",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Iziet",
     "loginLogo": "Logo",
     "loginTotpCode": "Vienreizējās paroles kods",

--- a/src/resources/l10n/mk.json
+++ b/src/resources/l10n/mk.json
@@ -205,6 +205,7 @@
     "loginCreated": "Нов корисник е регистриран",
     "loginResetSuccess": "Проверете ја вашата e-mail адреса",
     "loginUpdateSuccess": "Новата лозинка е поставена",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Одјава",
     "loginLogo": "Лого",
     "loginTotpCode": "Еднократен код за лозинка",

--- a/src/resources/l10n/ml.json
+++ b/src/resources/l10n/ml.json
@@ -205,6 +205,7 @@
     "loginCreated": "പുതിയ ഉപയോക്താവ് രജിസ്റ്റർ ചെയ്തു",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "പുറത്തുകടക്കുക",
     "loginLogo": "ലോഗോ",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/mn.json
+++ b/src/resources/l10n/mn.json
@@ -205,6 +205,7 @@
     "loginCreated": "Шинэ хэрэглэгч бүртгэгдлээ",
     "loginResetSuccess": "Имэйлээ шалгана уу",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Системээс гарах",
     "loginLogo": "Лого",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ms.json
+++ b/src/resources/l10n/ms.json
@@ -205,6 +205,7 @@
     "loginCreated": "Pengguna baru telah didaftarkan",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Keluar",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/nb.json
+++ b/src/resources/l10n/nb.json
@@ -205,6 +205,7 @@
     "loginCreated": "Ny bruker har blitt registrert",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logg ut",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ne.json
+++ b/src/resources/l10n/ne.json
@@ -205,6 +205,7 @@
     "loginCreated": "नया प्रयोगकर्ता दर्ता भयो ",
     "loginResetSuccess": "आफ्नो इमेल जाँच गर्नुहोस्",
     "loginUpdateSuccess": "नयाँ पासवर्ड सेट गरिएको छ",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "बाहिरिने ",
     "loginLogo": "लोगो",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/nl.json
+++ b/src/resources/l10n/nl.json
@@ -205,6 +205,7 @@
     "loginCreated": "De nieuwe gebruiker is geregistreerd",
     "loginResetSuccess": "Check je e-mail",
     "loginUpdateSuccess": "Het wachtwoord is ingesteld",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Afmelden",
     "loginLogo": "Logo",
     "loginTotpCode": "Eenmalig wachtwoord",

--- a/src/resources/l10n/nn.json
+++ b/src/resources/l10n/nn.json
@@ -205,6 +205,7 @@
     "loginCreated": "Ny brukar har blitt registrert",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logg ut",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/pl.json
+++ b/src/resources/l10n/pl.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nowy użytkownik został zarejestrowany",
     "loginResetSuccess": "Sprawdź swój e-mail",
     "loginUpdateSuccess": "Nowe hasło zostało ustawione",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Wyloguj",
     "loginLogo": "Logo",
     "loginTotpCode": "Kod hasła jednorazowego",

--- a/src/resources/l10n/pt.json
+++ b/src/resources/l10n/pt.json
@@ -205,6 +205,7 @@
     "loginCreated": "Novo utilizador foi registado",
     "loginResetSuccess": "Verifique o seu e-mail",
     "loginUpdateSuccess": "Nova password definida",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Sair",
     "loginLogo": "Logótipo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/pt_BR.json
+++ b/src/resources/l10n/pt_BR.json
@@ -205,6 +205,7 @@
     "loginCreated": "Novo usuário registrado",
     "loginResetSuccess": "Verifique seu e-mail",
     "loginUpdateSuccess": "Nova senha definida",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Sair",
     "loginLogo": "Logotipo",
     "loginTotpCode": "Código One-time Password",

--- a/src/resources/l10n/ro.json
+++ b/src/resources/l10n/ro.json
@@ -205,6 +205,7 @@
     "loginCreated": "Un nou utilizator a fost înregistrat",
     "loginResetSuccess": "Verifică email",
     "loginUpdateSuccess": "Noua parolă a fost configurată",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Deconectare",
     "loginLogo": "Logo",
     "loginTotpCode": "Cod Parolă One-time",

--- a/src/resources/l10n/ru.json
+++ b/src/resources/l10n/ru.json
@@ -205,6 +205,7 @@
     "loginCreated": "Новый пользователь зарегистрирован",
     "loginResetSuccess": "Проверьте свою электронную почту",
     "loginUpdateSuccess": "Новый пароль установлен",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Выход",
     "loginLogo": "Логотип",
     "loginTotpCode": "Одноразовый пароль",

--- a/src/resources/l10n/si.json
+++ b/src/resources/l10n/si.json
@@ -205,6 +205,7 @@
     "loginCreated": "නව පරිශීලකයෙකු ලියාපදිංචි වී ඇත",
     "loginResetSuccess": "ඔබගේ විද්යුත් තැපෑල පරීක්ෂා කරන්න",
     "loginUpdateSuccess": "නව මුරපදය සකසා ඇත",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "නික්මෙන්න",
     "loginLogo": "ලාංඡනය",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/sk.json
+++ b/src/resources/l10n/sk.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nový užívateľ sa zaregistroval",
     "loginResetSuccess": "Skontrolujte E-Mail",
     "loginUpdateSuccess": "Nové heslo je nastavené",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Odhlásiť",
     "loginLogo": "Logo",
     "loginTotpCode": "Kód dvojfaktorového overovania",

--- a/src/resources/l10n/sl.json
+++ b/src/resources/l10n/sl.json
@@ -205,6 +205,7 @@
     "loginCreated": "Nov uporabnik je registriran",
     "loginResetSuccess": "Prosimo preverite svojo e-pošto",
     "loginUpdateSuccess": "Novo geslo je shranjeno",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Odjava",
     "loginLogo": "Logotip",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/sq.json
+++ b/src/resources/l10n/sq.json
@@ -205,6 +205,7 @@
     "loginCreated": "Përdoruesi i ri u regjistrua",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Shkëputu",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/sr.json
+++ b/src/resources/l10n/sr.json
@@ -205,6 +205,7 @@
     "loginCreated": "Novi korisnik je registrovan",
     "loginResetSuccess": "Proverite Vaš email",
     "loginUpdateSuccess": "Nova lozinka je postavljena",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Odjava",
     "loginLogo": "Logo",
     "loginTotpCode": "Jednokratni kod lozinke",

--- a/src/resources/l10n/sv.json
+++ b/src/resources/l10n/sv.json
@@ -205,6 +205,7 @@
     "loginCreated": "Ny användare har blivit registrerad",
     "loginResetSuccess": "Kontrollera din Email",
     "loginUpdateSuccess": "Nytt lösenord är sparat",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logga ut",
     "loginLogo": "Logo",
     "loginTotpCode": "Engångslösenordskod",

--- a/src/resources/l10n/sw.json
+++ b/src/resources/l10n/sw.json
@@ -205,6 +205,7 @@
     "loginCreated": "Mtumiaji mpya amesajiliwa",
     "loginResetSuccess": "Angalia barua pepe yako",
     "loginUpdateSuccess": "Nenosiri jipya limewekwa",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Ondoka",
     "loginLogo": "Nembo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/ta.json
+++ b/src/resources/l10n/ta.json
@@ -205,6 +205,7 @@
     "loginCreated": "புதிய பயனர் பதிவு செய்யப்பட்டுள்ளது",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "வெளியேறு",
     "loginLogo": "இலட்சினை ",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/th.json
+++ b/src/resources/l10n/th.json
@@ -205,6 +205,7 @@
     "loginCreated": "ผู้ใช้ใหม่ ได้รับการลงทะเบียน",
     "loginResetSuccess": "ตรวจสอบอีเมลของคุณ",
     "loginUpdateSuccess": "ตั้งรหัสผ่านใหม่แล้ว",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "ออกจากระบบ",
     "loginLogo": "Logo",
     "loginTotpCode": "รหัสผ่านแบบใช้ครั้งเดียว",

--- a/src/resources/l10n/tk.json
+++ b/src/resources/l10n/tk.json
@@ -205,6 +205,7 @@
     "loginCreated": "New user has been registered",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Logout",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/tr.json
+++ b/src/resources/l10n/tr.json
@@ -205,6 +205,7 @@
     "loginCreated": "Yeni kullanıcı kaydedildi",
     "loginResetSuccess": "E-postanı kontrol et",
     "loginUpdateSuccess": "Yeni şifre belirlendi",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Oturumu sonlandır",
     "loginLogo": "Logo",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/uk.json
+++ b/src/resources/l10n/uk.json
@@ -205,6 +205,7 @@
     "loginCreated": "Новий користувач був зареєстрований",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Вийти",
     "loginLogo": "Логотип",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/uz.json
+++ b/src/resources/l10n/uz.json
@@ -205,6 +205,7 @@
     "loginCreated": "Янги фойдаланувчи рўйхатдан ўтди",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Чиқиш",
     "loginLogo": "Логотип",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/vi.json
+++ b/src/resources/l10n/vi.json
@@ -205,6 +205,7 @@
     "loginCreated": "Người dùng mới đã được đăng ký",
     "loginResetSuccess": "Check your email",
     "loginUpdateSuccess": "New password is set",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "Đăng xuất",
     "loginLogo": "Biểu tượng",
     "loginTotpCode": "One-time Password Code",

--- a/src/resources/l10n/zh.json
+++ b/src/resources/l10n/zh.json
@@ -205,6 +205,7 @@
     "loginCreated": "新用户已注册成功",
     "loginResetSuccess": "查看您的电子邮件",
     "loginUpdateSuccess": "密码已重置",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "注销",
     "loginLogo": "图标",
     "loginTotpCode": "一次性密码",

--- a/src/resources/l10n/zh_TW.json
+++ b/src/resources/l10n/zh_TW.json
@@ -205,6 +205,7 @@
     "loginCreated": "已成功註冊新用戶",
     "loginResetSuccess": "郵件查詢",
     "loginUpdateSuccess": "新密碼已重置",
+    "loginWelcomeMessage": "Welcome! Please sign in to continue.",
     "loginLogout": "登出",
     "loginLogo": "標識",
     "loginTotpCode": "一次性密碼",


### PR DESCRIPTION
## Summary
- add a loginWelcomeMessage string to every locale so the login welcome text can be localized
- render the welcome heading on the login page through the translation function

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de7368cf68832b85b9da2fed185177